### PR TITLE
fix type

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -316,7 +316,7 @@ type Order struct {
 
 	// If you pass is_raise_exact = TRUE, you must use quote_value = n where n is the amount you want,
 	// so $2000 will then cost you 1 ETH + fee, requiring > 1 ETH
-	IsRaiseExact string `json:"is_raise_exact,omitempty"`
+	IsRaiseExact bool `json:"is_raise_exact,omitempty"`
 
 	// Used for describe order, create order preview, and list portfolio orders
 	Id                    string `json:"id,omitempty"`


### PR DESCRIPTION
fix

`json: cannot unmarshal bool into Go struct field Order.orders.is_raise_exact of type string`

when calling [/primerestapi_getopenorders](https://github.com/coinbase-samples/prime-sdk-go/blob/main/orders/list_open_orders.go#L51)
